### PR TITLE
Remove: email password directly exposed

### DIFF
--- a/server/user/views.py
+++ b/server/user/views.py
@@ -41,7 +41,7 @@ def loginView(request):
         )
         res.data = tokens
         res["X-CSRFToken"] = csrf.get_token(request)
-        logger.info("Successful login for email: %s, password: %s", email, password)
+        logger.info("Successful login")
         return res
     logger.warn("Login failed for email: %s", email)
     raise rest_exceptions.AuthenticationFailed("Email or Password is incorrect!")


### PR DESCRIPTION
The email and password is directly exposing on console. I removed the direct print statement and replace it with appropriate message.